### PR TITLE
Select Purge Mode when Purge Warning Starts.

### DIFF
--- a/src/compressor_monitor.ino
+++ b/src/compressor_monitor.ino
@@ -569,7 +569,7 @@ void updateState(const uint64_t currentTimeMs)
 #endif
 
     int64_t timeUntilPurgeMs = getTimeUntilPurgeMs();
-    if (timeUntilPurgeMs <= 0) {
+    if (timeUntilPurgeMs < WARN_TIME_S * MS_PER_S) {
         if (!lastPurgeNeededState) {
             state.inputState = INPUT_STATE_PURGE;
             lastPurgeNeededState = true;


### PR DESCRIPTION
Select 'Purge' input mode when the warning interval for purge starts.